### PR TITLE
Features/12 add boolean parameters to all add link methods

### DIFF
--- a/Library/Extensions.cs
+++ b/Library/Extensions.cs
@@ -97,14 +97,14 @@ namespace MeyerCorp.HateoasBuilder
         {
             return condition
                 ? baseUrl.AddLink(relLabel, String.Format(relPathFormat, formatItems))
-                : new LinkBuilder(baseUrl);
+                : new LinkBuilder(!condition,baseUrl);
         }
 
         public static LinkBuilder AddFormattedLink(this HttpContext httpContext, bool condition, string relLabel, string relPathFormat, params object[] formatItems)
         {
             return condition
                 ? httpContext.AddFormattedLink(relLabel, relPathFormat, formatItems)
-                : new LinkBuilder(httpContext);
+                : new LinkBuilder(!condition,httpContext);
         }
 
         public static LinkBuilder AddQueryLink(this string baseUrl, string relLabel, string relativeUrl, params object[] queryPairs)
@@ -121,14 +121,14 @@ namespace MeyerCorp.HateoasBuilder
         {
             return condition
                 ? baseUrl.AddRouteLink(relLabel, relativeUrl).AddParameters(queryPairs)
-                : new LinkBuilder(baseUrl);
+                : new LinkBuilder(!condition,baseUrl);
         }
 
         public static LinkBuilder AddQueryLink(this HttpContext httpContext, bool condition, string relLabel, string relativeUrl, params object[] queryPairs)
         {
             return condition
                 ? httpContext.AddRouteLink(relLabel, relativeUrl).AddParameters(queryPairs)
-                : new LinkBuilder(httpContext);
+                : new LinkBuilder(!condition, httpContext);
         }
 
         public static LinkBuilder AddRouteLink(this HttpContext httpContext, string relLabel, params object[] routeItems)
@@ -156,14 +156,14 @@ namespace MeyerCorp.HateoasBuilder
         {
             return condition
                 ? httpContext.AddRouteLink(relLabel, routeItems)
-                : new LinkBuilder(httpContext);
+                : new LinkBuilder(!condition, httpContext);
         }
 
         public static LinkBuilder AddRouteLink(this string baseUrl, bool condition, string relLabel, params object[] routeItems)
         {
             return condition
                 ? baseUrl.AddRouteLink(relLabel, routeItems)
-                : new LinkBuilder(baseUrl);
+                : new LinkBuilder(!condition, baseUrl);
         }
 
         // public static LinkBuilder AddFormattedLinks(this string baseUrl, string rel, string format, IEnumerable<string> items)
@@ -188,13 +188,13 @@ namespace MeyerCorp.HateoasBuilder
             return links.Single(l => l.Rel == rel).Href;
         }
 
-        // public static TResult[] ToNullFilteredArray<TSource, TResult>(this IEnumerable<TSource> source, Func<TSource, TResult> selector)
-        // {
-        //     return source
-        //         .Select(v => selector(v))
-        //         .Where(v => v != null)
-        //         .ToArray();
-        // }
+        public static string CheckIfNullOrWhiteSpace(this string value, string parameterName)
+        {
+            if (String.IsNullOrWhiteSpace(value))
+                throw new ArgumentException("Parameter cannot be null, empty, or whitespace.", parameterName);
+            else
+                return value.Trim();
+        }
 
         /// <summary>
         /// Extension method allowing convenient sequential generation of hash values for overriding GetHash methods.
@@ -213,14 +213,6 @@ namespace MeyerCorp.HateoasBuilder
             return value == null
                 ? hash
                 : hash * seed + value.GetHashCode();
-        }
-
-        public static string CheckIfNullOrWhiteSpace(this string value, string parameterName)
-        {
-            if (String.IsNullOrWhiteSpace(value))
-                throw new ArgumentException("Parameter cannot be null, empty, or whitespace.", parameterName);
-            else
-                return value.Trim();
         }
     }
 }

--- a/Library/Extensions.cs
+++ b/Library/Extensions.cs
@@ -14,6 +14,16 @@ namespace MeyerCorp.HateoasBuilder
             list.Add(new Tuple<string, string?>(rel, rawRelativeUrl));
         }
 
+        internal static string ToBaseUrl(this HttpContext httpContext)
+        {
+            if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
+
+            var request = httpContext.Request;
+            var baseurl = $"{request.Scheme}://{request.Host}";
+
+            return baseurl;
+        }
+
         /// <summary>
         /// Create a name and hyperlink pair based on the current HttpContext which can be added to an API's HTTP response.
         /// </summary>
@@ -27,6 +37,18 @@ namespace MeyerCorp.HateoasBuilder
             var rel = relLabel.CheckIfNullOrWhiteSpace(nameof(relLabel));
 
             return new LinkBuilder(url, rel, rawRelativeUrl);
+        }
+
+        public static LinkBuilder AddLink(this string baseUrl, bool condition, string relLabel, string? rawRelativeUrl)
+        {
+            if (condition)
+                return baseUrl.AddLink(relLabel, rawRelativeUrl);
+            else
+            {
+                var url = baseUrl.CheckIfNullOrWhiteSpace(nameof(baseUrl));
+
+                return new LinkBuilder(url);
+            }
         }
 
         /// <summary>
@@ -46,6 +68,19 @@ namespace MeyerCorp.HateoasBuilder
             return baseurl.AddLink(relLabel, rawRelativeUrl);
         }
 
+        public static LinkBuilder AddLink(this HttpContext httpContext, bool condition, string relLabel, string? rawRelativeUrl)
+        {
+
+            if (condition)
+                return httpContext.AddLink(relLabel, rawRelativeUrl);
+            else
+            {
+                if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
+
+                return new LinkBuilder(httpContext);
+            }
+        }
+
         public static LinkBuilder AddFormattedLink(this string baseUrl, string relLabel, string relPathFormat, params object[] formatItems)
         {
             return baseUrl.AddLink(relLabel, String.Format(relPathFormat, formatItems));
@@ -58,6 +93,20 @@ namespace MeyerCorp.HateoasBuilder
             return httpContext.AddLink(relLabel, String.Format(relPathFormat, formatItems));
         }
 
+        public static LinkBuilder AddFormattedLink(this string baseUrl, bool condition, string relLabel, string relPathFormat, params object[] formatItems)
+        {
+            return condition
+                ? baseUrl.AddLink(relLabel, String.Format(relPathFormat, formatItems))
+                : new LinkBuilder(baseUrl);
+        }
+
+        public static LinkBuilder AddFormattedLink(this HttpContext httpContext, bool condition, string relLabel, string relPathFormat, params object[] formatItems)
+        {
+            return condition
+                ? httpContext.AddFormattedLink(relLabel, relPathFormat, formatItems)
+                : new LinkBuilder(httpContext);
+        }
+
         public static LinkBuilder AddQueryLink(this string baseUrl, string relLabel, string relativeUrl, params object[] queryPairs)
         {
             return baseUrl.AddRouteLink(relLabel, relativeUrl).AddParameters(queryPairs);
@@ -66,6 +115,20 @@ namespace MeyerCorp.HateoasBuilder
         public static LinkBuilder AddQueryLink(this HttpContext httpContext, string relLabel, string relativeUrl, params object[] queryPairs)
         {
             return httpContext.AddRouteLink(relLabel, relativeUrl).AddParameters(queryPairs);
+        }
+
+        public static LinkBuilder AddQueryLink(this string baseUrl, bool condition, string relLabel, string relativeUrl, params object[] queryPairs)
+        {
+            return condition
+                ? baseUrl.AddRouteLink(relLabel, relativeUrl).AddParameters(queryPairs)
+                : new LinkBuilder(baseUrl);
+        }
+
+        public static LinkBuilder AddQueryLink(this HttpContext httpContext, bool condition, string relLabel, string relativeUrl, params object[] queryPairs)
+        {
+            return condition
+                ? httpContext.AddRouteLink(relLabel, relativeUrl).AddParameters(queryPairs)
+                : new LinkBuilder(httpContext);
         }
 
         public static LinkBuilder AddRouteLink(this HttpContext httpContext, string relLabel, params object[] routeItems)
@@ -89,16 +152,19 @@ namespace MeyerCorp.HateoasBuilder
             return baseUrl.AddLink(relLabel, output);
         }
 
-        // public static LinkBuilder AddRouteLink(this string baseUrl, string relLabel, string? relPathFormat = "", params object[] formatItems)
-        // {
-        //     if (String.IsNullOrWhiteSpace(baseUrl)) throw new ArgumentException("Parameter cannot be null, empty, or whitespace.", nameof(baseUrl));
-        //     if (String.IsNullOrWhiteSpace(relLabel)) throw new ArgumentException("Parameter cannot be null, empty, or whitespace.", nameof(relLabel));
+        public static LinkBuilder AddRouteLink(this HttpContext httpContext, bool condition, string relLabel, params object[] routeItems)
+        {
+            return condition
+                ? httpContext.AddRouteLink(relLabel, routeItems)
+                : new LinkBuilder(httpContext);
+        }
 
-        //     var output = new LinkBuilder(baseUrl);
-
-        //     return output.AddFormattedLink(relLabel, relPathFormat, formatItems);
-        // }
-
+        public static LinkBuilder AddRouteLink(this string baseUrl, bool condition, string relLabel, params object[] routeItems)
+        {
+            return condition
+                ? baseUrl.AddRouteLink(relLabel, routeItems)
+                : new LinkBuilder(baseUrl);
+        }
 
         // public static LinkBuilder AddFormattedLinks(this string baseUrl, string rel, string format, IEnumerable<string> items)
         // {
@@ -148,11 +214,6 @@ namespace MeyerCorp.HateoasBuilder
                 ? hash
                 : hash * seed + value.GetHashCode();
         }
-
-        // public static ArgumentException ToNullOrWhitespace(this string parameterName)
-        // {
-        //     return new ArgumentException("Parameter cannot be null, empty, or whitespace.", parameterName);
-        // }
 
         public static string CheckIfNullOrWhiteSpace(this string value, string parameterName)
         {

--- a/Library/Extensions.cs
+++ b/Library/Extensions.cs
@@ -7,11 +7,11 @@ namespace MeyerCorp.HateoasBuilder
 {
     public static class Extensions
     {
-        internal static void Add(this List<Tuple<string, string?>> list, string relLabel, string? rawRelativeUrl)
+        internal static void Add(this List<Tuple<string, LinkInformation>> list, string relLabel, string? rawRelativeUrl)
         {
             var rel = relLabel.CheckIfNullOrWhiteSpace(nameof(relLabel));
 
-            list.Add(new Tuple<string, string?>(rel, rawRelativeUrl));
+            list.Add(new Tuple<string, LinkInformation>(rel, new LinkInformation(rawRelativeUrl)));
         }
 
         internal static string ToBaseUrl(this HttpContext httpContext)
@@ -75,9 +75,7 @@ namespace MeyerCorp.HateoasBuilder
                 return httpContext.AddLink(relLabel, rawRelativeUrl);
             else
             {
-                if (httpContext == null) throw new ArgumentNullException(nameof(httpContext));
-
-                return new LinkBuilder(httpContext);
+                return new LinkBuilder(!condition, httpContext);
             }
         }
 
@@ -97,14 +95,14 @@ namespace MeyerCorp.HateoasBuilder
         {
             return condition
                 ? baseUrl.AddLink(relLabel, String.Format(relPathFormat, formatItems))
-                : new LinkBuilder(!condition,baseUrl);
+                : new LinkBuilder(!condition, baseUrl);
         }
 
         public static LinkBuilder AddFormattedLink(this HttpContext httpContext, bool condition, string relLabel, string relPathFormat, params object[] formatItems)
         {
             return condition
                 ? httpContext.AddFormattedLink(relLabel, relPathFormat, formatItems)
-                : new LinkBuilder(!condition,httpContext);
+                : new LinkBuilder(!condition, httpContext);
         }
 
         public static LinkBuilder AddQueryLink(this string baseUrl, string relLabel, string relativeUrl, params object[] queryPairs)
@@ -121,7 +119,7 @@ namespace MeyerCorp.HateoasBuilder
         {
             return condition
                 ? baseUrl.AddRouteLink(relLabel, relativeUrl).AddParameters(queryPairs)
-                : new LinkBuilder(!condition,baseUrl);
+                : new LinkBuilder(!condition, baseUrl);
         }
 
         public static LinkBuilder AddQueryLink(this HttpContext httpContext, bool condition, string relLabel, string relativeUrl, params object[] queryPairs)

--- a/Library/Library.csproj
+++ b/Library/Library.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>MeyerCorp.HateoasBuilder</AssemblyName>
     <RootNamespace>MeyerCorp.HateoasBuilder</RootNamespace>
     <PackageId>MeyerCorp.HateoasBuilder</PackageId>
-    <Version>1.4.0-preview-6</Version>
+    <Version>1.5.0-preview-7</Version>
     <Authors>danielpmeyer</Authors>
     <Company>MeyerCorporation</Company>
     <Description>Extension based builder for creating HATEOAS links in RESTful reponses in .NET.</Description>

--- a/Library/LinkBuilder.cs
+++ b/Library/LinkBuilder.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,17 +19,11 @@ namespace MeyerCorp.HateoasBuilder
         /// </summary>
         /// <param name="baseUrl">The base URL which all presented links will use</param>
         /// <exception cref="ArgumentNullException">The <paramref name="baseUrl"/> must not be null, empty, or whitespace.</exception>
-        public LinkBuilder(string baseUrl) => BaseUrl = baseUrl.CheckIfNullOrWhiteSpace(nameof(baseUrl));
+        internal LinkBuilder(string baseUrl) => BaseUrl = baseUrl.CheckIfNullOrWhiteSpace(nameof(baseUrl));
 
-        public LinkBuilder(string baseUrl, string relLabel, string? rawRelativeUrl) : this(baseUrl) => RelHrefPairs.Add(relLabel, rawRelativeUrl);
+        internal LinkBuilder(string baseUrl, string relLabel, string? rawRelativeUrl) : this(baseUrl) => RelHrefPairs.Add(relLabel, rawRelativeUrl);
 
-        // /// <summary>
-        // /// Link colleciton indexer
-        // /// </summary>
-        // /// <param name="index">Index which to retrieve.</param>
-        // /// <returns>Link object in the collection to return</returns>
-        // [JsonProperty]
-        // public Link this[int index] { get { return Build().ToArray()[index]; } }
+        internal LinkBuilder(HttpContext httpContext) : this(httpContext.ToBaseUrl()) { }
 
         /// <summary>
         /// The base URL which all presented links will use
@@ -44,7 +39,7 @@ namespace MeyerCorp.HateoasBuilder
         /// Build all added links and yield as a collection of links.
         /// </summary>
         /// <exception cref="ArgumentNullException">The <paramref name="baseUrl"/> must not be null, empty, or whitespace.</exception>
-        IEnumerable<Link> Build(bool encode)
+        public IEnumerable<Link> Build(bool encode = false)
         {
             return RelHrefPairs
                 .Select(p =>
@@ -57,12 +52,6 @@ namespace MeyerCorp.HateoasBuilder
                     return new Link(p.Item1, href);
                 });
         }
-
-        /// <summary>
-        /// Build all added links and yield as a collection of links.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The <paramref name="baseUrl"/> must not be null, empty, or whitespace.</exception>
-        public IEnumerable<Link> Build() => Build(false);
 
         /// <summary>
         /// Build all added links and yield as a collection of links all of which are URL encoded.
@@ -78,33 +67,30 @@ namespace MeyerCorp.HateoasBuilder
         /// <returns>This LinkBuilder object which can be used to add more links before calling the Build method.</returns>
         public LinkBuilder AddLink(string relLabel, string rawRelativeUrl)
         {
-            relLabel.CheckIfNullOrWhiteSpace(nameof(relLabel));
-            // rawRelativeUrl.CheckIfNullOrWhiteSpace(nameof(rawRelativeUrl));
+            var rel = relLabel.CheckIfNullOrWhiteSpace(nameof(relLabel));
 
-            RelHrefPairs.Add(relLabel, rawRelativeUrl);
+            RelHrefPairs.Add(rel, rawRelativeUrl);
 
             return this;
         }
 
-        /// <summary>
-        /// Add a link based on a format string and necessary parameters
-        /// </summary>
-        /// <param name="relLabel"></param>
-        /// <param name="relativeUrlFormat"></param>
-        /// <param name="formattedItems"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        public LinkBuilder AddFormattedLink(string relLabel, string relativeUrlFormat, params object[] formattedItems)
+        public LinkBuilder AddLink(bool condition, string relLabel, string rawRelativeUrl)
         {
-            if (formattedItems == null) throw new ArgumentNullException(nameof(formattedItems));
-            relativeUrlFormat.CheckIfNullOrWhiteSpace(nameof(relativeUrlFormat));
-
-            return AddLink(relLabel, String.Format(relativeUrlFormat, formattedItems));
+            return condition
+                ? AddLink(relLabel, rawRelativeUrl)
+                : this;
         }
-
+       
         public LinkBuilder AddQueryLink(string relLabel, string relativeUrl, params object[] queryPairs)
         {
             return AddRouteLink(relLabel, relativeUrl).AddParameters(queryPairs);
+        }
+
+        public LinkBuilder AddQueryLink(bool condition, string relLabel, string relativeUrl, params object[] queryPairs)
+        {
+            return condition
+                ? AddQueryLink(relLabel, relativeUrl, relativeUrl, queryPairs)
+                : this;
         }
 
         public LinkBuilder AddRouteLink(string relLabel, string relativeUrl, params object[] routeItems)
@@ -121,6 +107,36 @@ namespace MeyerCorp.HateoasBuilder
                 : String.Concat(relativeUrl, '/');
 
             return AddLink(relLabel, String.Concat(relativeUrl, route));
+        }
+
+        public LinkBuilder AddRouteLink(bool condition, string relLabel, string relativeUrl, params object[] routeItems)
+        {
+            return condition
+                ? AddRouteLink(relLabel, relativeUrl, routeItems)
+                : this;
+        }
+
+        /// <summary>
+        /// Add a link based on a format string and necessary parameters
+        /// </summary>
+        /// <param name="relLabel"></param>
+        /// <param name="relativeUrlFormat"></param>
+        /// <param name="arguments"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public LinkBuilder AddFormattedLink(string relLabel, string relativeUrlFormat, params object[] arguments)
+        {
+            if (arguments == null) throw new ArgumentNullException(nameof(arguments));
+            relativeUrlFormat.CheckIfNullOrWhiteSpace(nameof(relativeUrlFormat));
+
+            return AddLink(relLabel, String.Format(relativeUrlFormat, arguments));
+        }
+
+        public LinkBuilder AddFormattedLink(bool condition, string relLabel, string relativeUrlFormat, params object[] arguments)
+        {
+            return condition
+                ? AddFormattedLink(relLabel, relativeUrlFormat, relativeUrlFormat, arguments)
+                : this;
         }
 
         /// <summary>
@@ -183,60 +199,23 @@ namespace MeyerCorp.HateoasBuilder
         //     return this;
         // }
 
-        // /// <summary>
-        // /// Add a link based on a format string and necessary parameters
-        // /// </summary>
-        // /// <param name="relLabel"></param>
-        // /// <param name="relativeUrlFormat"></param>
-        // /// <param name="formattedItems"></param>
-        // /// <returns></returns>
-        // /// <exception cref="ArgumentNullException"></exception>
-        // public LinkBuilder AddFormattedLink(string relLabel, string? relPathFormat = "", params object[] formatItems)
+        // public LinkBuilder AddFormattedLinks(string relLabel, string relPathFormat, IEnumerable<string> items)
         // {
         //     if (String.IsNullOrWhiteSpace(relLabel)) throw new ArgumentException("Parameter cannot be null, empty, or whitespace.", nameof(relLabel));
-        //     if (String.IsNullOrWhiteSpace(relativeUrlFormat)) throw new ArgumentException("Parameter cannot be null, empty, or whitespace.", nameof(relativeUrlFormat));
+        //     if (String.IsNullOrWhiteSpace(relPathFormat)) throw new ArgumentException("Parameter cannot be null, empty, or whitespace.", nameof(relPathFormat));
+        //     if (items == null) throw new ArgumentNullException(nameof(relPathFormat));
 
-        //     if (formattedItems.Length < 1 && !String.IsNullOrWhiteSpace(relativeUrlFormat))
+        //     if (!String.IsNullOrWhiteSpace(relPathFormat) && items != null)
         //     {
-        //         RelHrefPairs.Add(relLabel);
-        //         RelHrefPairs.Add(String.Concat(BaseUrl, relativeUrlFormat));
-        //     }
-        //     else if (formattedItems.Length > 0 && !formattedItems.Any(i => i == null || String.IsNullOrWhiteSpace(i.ToString())))
-        //     {
-        //         RelHrefPairs.Add(relLabel);
-        //         RelHrefPairs.Add(String.Concat(BaseUrl, String.Format(relativeUrlFormat, formattedItems)));
+        //         foreach (var item in items.Where(i => i != null && !String.IsNullOrWhiteSpace(i.ToString())))
+        //         {
+        //             var formatitems = item.Split(',');
+
+        //             AddFormattedLink(relLabel, relPathFormat, formatitems);
+        //         }
         //     }
 
         //     return this;
+        // }
     }
-
-    // public LinkBuilder AddFormattedLinkIf(bool condition, string relLabel, string relPathFormat, params object[] formatItems)
-    // {
-    //     if (String.IsNullOrWhiteSpace(relLabel)) throw new ArgumentException("Parameter cannot be null, empty, or whitespace.", nameof(relLabel));
-    //     if (String.IsNullOrWhiteSpace(relPathFormat)) throw new ArgumentException("Parameter cannot be null, empty, or whitespace.", nameof(relLabel));
-
-    //     if (condition)
-    //         AddFormattedLink(relLabel, relPathFormat, formatItems);
-
-    //     return this;
-    // }
-
-    // public LinkBuilder AddFormattedLinks(string relLabel, string relPathFormat, IEnumerable<string> items)
-    // {
-    //     if (String.IsNullOrWhiteSpace(relLabel)) throw new ArgumentException("Parameter cannot be null, empty, or whitespace.", nameof(relLabel));
-    //     if (String.IsNullOrWhiteSpace(relPathFormat)) throw new ArgumentException("Parameter cannot be null, empty, or whitespace.", nameof(relPathFormat));
-    //     if (items == null) throw new ArgumentNullException(nameof(relPathFormat));
-
-    //     if (!String.IsNullOrWhiteSpace(relPathFormat) && items != null)
-    //     {
-    //         foreach (var item in items.Where(i => i != null && !String.IsNullOrWhiteSpace(i.ToString())))
-    //         {
-    //             var formatitems = item.Split(',');
-
-    //             AddFormattedLink(relLabel, relPathFormat, formatitems);
-    //         }
-    //     }
-
-    //     return this;
-    // }
 }

--- a/Library/LinkBuilder.cs
+++ b/Library/LinkBuilder.cs
@@ -12,7 +12,7 @@ namespace MeyerCorp.HateoasBuilder
         private string baseUrl = default!;
 
         [JsonIgnore]
-        List<Tuple<string, string?>> RelHrefPairs { get; set; } = new List<Tuple<string, string?>>();
+        List<Tuple<string, LinkInformation>> RelHrefPairs { get; set; } = new List<Tuple<string, LinkInformation>>();
 
         /// <summary>
         /// Default constructor
@@ -29,7 +29,7 @@ namespace MeyerCorp.HateoasBuilder
 
         internal LinkBuilder(string baseUrl, string relLabel, string? rawRelativeUrl) : this(baseUrl) => RelHrefPairs.Add(relLabel, rawRelativeUrl);
 
-        internal LinkBuilder(HttpContext httpContext) : this(httpContext.ToBaseUrl()) { }
+        // internal LinkBuilder(HttpContext httpContext) : this(httpContext.ToBaseUrl()) { }
 
         internal LinkBuilder(bool lastIgnored, HttpContext httpContext) : this(lastIgnored, httpContext.ToBaseUrl()) { }
 
@@ -52,16 +52,16 @@ namespace MeyerCorp.HateoasBuilder
         /// <exception cref="ArgumentNullException">The <paramref name="baseUrl"/> must not be null, empty, or whitespace.</exception>
         public IEnumerable<Link> Build(bool encode = false)
         {
-            return RelHrefPairs
-                .Select(p =>
-                {
-                    var relativeurl = encode
-                        ? System.Web.HttpUtility.UrlEncode(p.Item2?.Trim())
-                        : p.Item2?.Trim();
-                    var href = String.Concat(BaseUrl, '/', relativeurl).Trim('/');
+            return RelHrefPairs.Select(p =>
+            {
+                var url = new StringBuilder();
+                var relativeurl = p.Item2.GetUrl(encode);
 
-                    return new Link(p.Item1, href);
-                });
+                url.Append(baseUrl);
+                if (String.IsNullOrWhiteSpace(relativeurl)) url.AppendFormat("/{0}", relativeurl);
+
+                return new Link(p.Item1, url.ToString());
+            });
         }
 
         /// <summary>

--- a/Library/LinkInformation.cs
+++ b/Library/LinkInformation.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace MeyerCorp.HateoasBuilder
@@ -10,29 +11,63 @@ namespace MeyerCorp.HateoasBuilder
 
         internal LinkInformation(string? rawRelativeUrl)
         {
-            RelativeUrl = rawRelativeUrl ?? String.Empty;
+            RelativeUrl = rawRelativeUrl?.Trim() ?? String.Empty;
         }
 
-        internal List<string> RouteItems { get; } = new List<string>();
-        internal List<string> QueryItems { get; } = new List<string>();
+        internal LinkInformation(IEnumerable<object>? routeItems, IEnumerable<object>? queryItems)
+        {
+            if (routeItems != null) RouteItems.AddRange(routeItems);
+            if (queryItems != null) QueryItems.AddRange(queryItems);
+        }
+
+        internal List<object> RouteItems { get; } = new List<object>();
+        internal List<object> QueryItems { get; } = new List<object>();
 
         internal string GetUrl(bool encode)
         {
             if (RouteItems.Count == 0 && QueryItems.Count == 0)
-                return RelativeUrl.Trim();
+                return RelativeUrl;
             else
             {
-                var route = string.Join('/', RouteItems);
-                var query = string.Join('&', QueryItems);
+                var routes = RouteItems
+                    .Where(ri => !String.IsNullOrWhiteSpace(ri?.ToString()))
+                    .Select(i => i?.ToString());
+
+                var queries = Concatenate(QueryItems);
+
+                var route = string.Join('/', routes);
                 var output = new StringBuilder();
 
-                output.Append(route);
-                if (string.IsNullOrWhiteSpace(query)) output.AppendFormat("?{0}", query);
+                output.Append(RelativeUrl.Trim());
+                output.Append(route.Trim());
+                if (!string.IsNullOrWhiteSpace(queries)) output.AppendFormat("?{0}", queries);
 
                 return encode
                     ? System.Web.HttpUtility.UrlEncode(output.ToString())
                     : output.ToString();
             }
+        }
+
+        static string Concatenate(IEnumerable<object> queryItems)
+        {
+            if (queryItems == null) throw new ArgumentNullException(nameof(queryItems));
+
+            var output = new StringBuilder();
+            var items = queryItems.ToArray();
+
+            for (var index = 0; index < queryItems.Count(); index += 2)
+            {
+                var name = items[index]?.ToString().Trim();
+                var value = items.Length > index + 1
+                     ? items[index + 1]?.ToString().Trim() ?? String.Empty
+                     : String.Empty;
+
+                if (String.IsNullOrWhiteSpace(name)) throw new ArgumentException("Parameter names cannot be null, empty, or whitespace.");
+
+                output.AppendFormat("{0}={1}&", name, value);
+            }
+
+            return output.ToString().Trim('&');
         }
     }
 }

--- a/Library/LinkInformation.cs
+++ b/Library/LinkInformation.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MeyerCorp.HateoasBuilder
+{
+    internal class LinkInformation
+    {
+        readonly string RelativeUrl = String.Empty;
+
+        internal LinkInformation(string? rawRelativeUrl)
+        {
+            RelativeUrl = rawRelativeUrl ?? String.Empty;
+        }
+
+        internal List<string> RouteItems { get; } = new List<string>();
+        internal List<string> QueryItems { get; } = new List<string>();
+
+        internal string GetUrl(bool encode)
+        {
+            if (RouteItems.Count == 0 && QueryItems.Count == 0)
+                return RelativeUrl.Trim();
+            else
+            {
+                var route = string.Join('/', RouteItems);
+                var query = string.Join('&', QueryItems);
+                var output = new StringBuilder();
+
+                output.Append(route);
+                if (string.IsNullOrWhiteSpace(query)) output.AppendFormat("?{0}", query);
+
+                return encode
+                    ? System.Web.HttpUtility.UrlEncode(output.ToString())
+                    : output.ToString();
+            }
+        }
+    }
+}

--- a/Test/AddLinkTests.cs
+++ b/Test/AddLinkTests.cs
@@ -43,9 +43,9 @@ namespace MeyerCorp.HateoasBuilder.Test
         [Theory(DisplayName = "String.AddLink false (pass)")]
         [InlineData("https://foo.bar/dingle/ball?value1=1&value2=2", false, 1, "dingle/ball?value1=1&value2=2")]
         [InlineData("https://foo.bar/dingle", true, 1, "dingle")]
-        // [InlineData("https://foo.bar", false, null)]
-        // [InlineData("https://foo.bar", false, "")]
-        // [InlineData("https://foo.bar", false, "\t")]
+        [InlineData("https://foo.bar", false, 1, null)]
+        [InlineData("https://foo.bar", false, 1, "")]
+        [InlineData("https://foo.bar", false, 1, "\t")]
         public void AddLinkStringFalsePassTest(string result, bool condition, int count, string relativeUrl)
         {
             var links = baseUrl

--- a/Test/AddParametersTests.cs
+++ b/Test/AddParametersTests.cs
@@ -6,7 +6,7 @@ namespace MeyerCorp.HateoasBuilder.Test
 {
     public class AddParametersTests : ExtensionTest
     {
-        [Theory(DisplayName = "HttpContext.AddLink (pass)")]
+        [Theory(DisplayName = "HttpContext.AddLink.AddParameters (pass)")]
         [InlineData(true)]
         [InlineData(false)]
         public void AddParametersToAddLinkTrueTest(bool condition)
@@ -23,7 +23,7 @@ namespace MeyerCorp.HateoasBuilder.Test
             Assert.Equal(rel, links.First().Rel);
         }
 
-        [Theory(DisplayName = "HttpContext.AddLink (pass)")]
+        [Theory(DisplayName = "HttpContext.AddRouteLink.AddParameters (pass)")]
         [InlineData(true)]
         [InlineData(false)]
         public void AddParametersToAddRouteLinkTrueTest(bool condition)
@@ -40,7 +40,7 @@ namespace MeyerCorp.HateoasBuilder.Test
             Assert.Equal(rel, links.First().Rel);
         }
 
-        [Theory(DisplayName = "HttpContext.AddQueryLink (pass)")]
+        [Theory(DisplayName = "HttpContext.AddQueryLink.AddParameters (pass)")]
         [InlineData(true)]
         [InlineData(false)]
         public void AddParametersToAddQueryLinkTrueTest(bool condition)

--- a/Test/AddParametersTests.cs
+++ b/Test/AddParametersTests.cs
@@ -4,57 +4,57 @@ using Xunit;
 
 namespace MeyerCorp.HateoasBuilder.Test
 {
-    public class AddLinkTests : ExtensionTest
+    public class AddParametersTests : ExtensionTest
     {
         [Theory(DisplayName = "HttpContext.AddLink (pass)")]
-        [InlineData("https://foo.bar/dingle/ball?value1=1&value2=2", "dingle/ball?value1=1&value2=2")]
-        [InlineData("https://foo.bar/dingle", "dingle")]
-        [InlineData("https://foo.bar", null)]
-        [InlineData("https://foo.bar", "")]
-        [InlineData("https://foo.bar", "\t")]
-        public void AddLinkHttpContextPassTest(string result, string relativeUrl)
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AddParametersToAddLinkTrueTest(bool condition)
         {
             var links = GetHttpContext()
-                .AddLink(rel, relativeUrl)
+                .AddLink(condition, rel, "relativeUrl")
+                .AddParameters("name", "value")
+                .AddLink(!condition, rel, "relativeUrl")
+                .AddParameters("name", "value")
                 .Build();
 
             Assert.Single(links);
-            Assert.Equal(result, links.First().Href);
+            Assert.Equal("https://foo.bar/relativeUrl?name=value", links.First().Href);
             Assert.Equal(rel, links.First().Rel);
         }
 
-        [Theory(DisplayName = "String.AddLink (pass)")]
-        [InlineData("https://foo.bar/dingle/ball?value1=1&value2=2", "dingle/ball?value1=1&value2=2")]
-        [InlineData("https://foo.bar/dingle", "dingle")]
-        [InlineData("https://foo.bar", null)]
-        [InlineData("https://foo.bar", "")]
-        [InlineData("https://foo.bar", "\t")]
-        public void AddLinkStringPassTest(string result, string relativeUrl)
+        [Theory(DisplayName = "HttpContext.AddLink (pass)")]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AddParametersToAddRouteLinkTrueTest(bool condition)
         {
-            var links = baseUrl
-                .AddLink(rel, relativeUrl)
+            var links = GetHttpContext()
+                .AddRouteLink(condition, rel, "relativeUrl")
+                .AddParameters("name", "value")
+                .AddRouteLink(!condition, rel, "relativeUrl")
+                .AddParameters("name", "value")
                 .Build();
 
             Assert.Single(links);
-            Assert.Equal(result, links.First().Href);
+            Assert.Equal("https://foo.bar/relativeUrl?name=value", links.First().Href);
             Assert.Equal(rel, links.First().Rel);
         }
 
-        [Theory(DisplayName = "String.AddLink false (pass)")]
-        [InlineData("https://foo.bar/dingle/ball?value1=1&value2=2", false, 1, "dingle/ball?value1=1&value2=2")]
-        [InlineData("https://foo.bar/dingle", true, 1, "dingle")]
-        // [InlineData("https://foo.bar", false, null)]
-        // [InlineData("https://foo.bar", false, "")]
-        // [InlineData("https://foo.bar", false, "\t")]
-        public void AddLinkStringFalsePassTest(string result, bool condition, int count, string relativeUrl)
+        [Theory(DisplayName = "HttpContext.AddQueryLink (pass)")]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void AddParametersToAddQueryLinkTrueTest(bool condition)
         {
-            var links = baseUrl
-                .AddLink(condition, rel, relativeUrl)
-                .AddLink(!condition, rel, relativeUrl)
+            var links = GetHttpContext()
+                .AddQueryLink(condition, rel, "relativeUrl", "name1", "value1")
+                .AddParameters("name", "value")
+                .AddQueryLink(!condition, rel, "relativeUrl", "name1", "value1")
+                .AddParameters("name", "value")
                 .Build();
 
-            Assert.Equal(count, links.Count());
-            if (count > 0) Assert.Equal(new Link(rel, result), links.First());
+            Assert.Single(links);
+            Assert.Equal("https://foo.bar/relativeUrl?name1=value1&name=value", links.First().Href);
+            Assert.Equal(rel, links.First().Rel);
         }
 
         [Theory(DisplayName = "HttpContext.AddLink (fail)")]

--- a/Test/LinkBuilderTest.cs
+++ b/Test/LinkBuilderTest.cs
@@ -7,15 +7,29 @@ namespace MeyerCorp.HateoasBuilder.Test
 {
     public class LinkBuilderTest : ExtensionTest
     {
-        [Theory(DisplayName = "Constructor (fail).")]
-        [InlineData("")]
-        [InlineData("\t")]
-        [InlineData(null)]
-        public void ConstructorFailTest(string baseUrl)
+        [Fact(DisplayName = "Contructor 1")]
+        public void Constructor1Test()
         {
-            var caught = Assert.Throws<ArgumentException>(() => new LinkBuilder(baseUrl));
+            var linkbuilder = baseUrl.AddLink("test", "relativeurl").Build();
 
-            Assert.Equal("Parameter cannot be null, empty, or whitespace. (Parameter 'baseUrl')", caught.Message);
+            Assert.Equal(new Link("test", "https://foo.bar/relativeurl"), linkbuilder.First());
+        }
+
+        [Fact(DisplayName = "Contructor 2")]
+        public void Constructor2Test()
+        {
+            var linkbuilder = GetHttpContext().AddLink("test", "relativeurl").Build();
+
+            Assert.Equal(new Link("test", "https://foo.bar/relativeurl"), linkbuilder.First());
+        }
+
+        [Fact(DisplayName = "Contructor 3")]
+        public void Constructor3Test()
+        {
+            var linkbuilder = GetHttpContext().AddLink(false, "test", "relativeurl");
+
+            Assert.Equal(baseUrl, linkbuilder.BaseUrl);
+            Assert.Empty(linkbuilder.Build());
         }
 
         [Fact(DisplayName = "BuildEncoded")]
@@ -45,7 +59,7 @@ namespace MeyerCorp.HateoasBuilder.Test
         [InlineData("asdf", "", new object[] { }, "Parameter cannot be null, empty, or whitespace. (Parameter 'relativeUrlFormat')")]
         public void LinkBuilder1Test(string? relLabel, string? relativeUrlFormat, IEnumerable<object> formatItems, string message)
         {
-            var test = new LinkBuilder("https:meyerus.com");
+            var test = "https:meyerus.com".AddLink("self", "baseUrl");
 
             var caught = Assert.Throws<ArgumentException>(() => test.AddFormattedLink(relLabel, relativeUrlFormat, formatItems));
 
@@ -58,12 +72,11 @@ namespace MeyerCorp.HateoasBuilder.Test
         [InlineData("http://foo.bar/asdftestdostres", "asdf{0}{1}{2}", new string[] { "test", "dos", "tres" })]
         public void LinkBuilder2Test(string result, string format, string[] items)
         {
-            const string rel = "rel";
-            var test = new LinkBuilder("http://foo.bar");
+            var test = "http://foo.bar".AddLink("self", "baseUrl");
 
             var links = test.AddFormattedLink(rel, format, items.ToArray()).Build();
-            Assert.Single(links);
-            Assert.Equal(new Link(rel, result), links.First());
+            Assert.Equal(2, links.Count());
+            Assert.Equal(new Link(rel, result), links.Last());
         }
 
         [Theory(DisplayName = "AddQueryLink (pass)")]
@@ -79,14 +92,14 @@ namespace MeyerCorp.HateoasBuilder.Test
         [InlineData("http://foo.bar/base?value2=2&value1=", "rel1", "base", "value2", "2", "value1", "\t")]
         public void LinkBuilder3Test(string result, string relLabel, string relativeUrl, string name1, object value1, string name2, object value2)
         {
-            var test = new LinkBuilder("http://foo.bar");
+            var test = "http://foo.bar".AddLink("self", "baseUrl");
 
             var links = test
                 .AddQueryLink(relLabel, relativeUrl, name1, value1, name2, value2)
                 .Build();
 
-            Assert.Equal(relLabel, links.First().Rel);
-            Assert.Equal(result, links.First().Href);
+            Assert.Equal(relLabel, links.Last().Rel);
+            Assert.Equal(result, links.Last().Href);
         }
 
         [Theory(DisplayName = "AddLink (pass)")]
@@ -96,12 +109,12 @@ namespace MeyerCorp.HateoasBuilder.Test
         [InlineData("http://foo.bar/value1", "base", "value1")]
         public void LinkBuilder4Test(string result, string relLabel, string rawRelativeUrl)
         {
-            var test = new LinkBuilder("http://foo.bar");
+            var test = "http://foo.bar".AddLink("self", "baseUrl");
 
             var links = test.AddLink(relLabel, rawRelativeUrl).Build();
 
-            Assert.Equal(relLabel, links.First().Rel);
-            Assert.Equal(result, links.First().Href);
+            Assert.Equal(relLabel, links.Last().Rel);
+            Assert.Equal(result, links.Last().Href);
         }
 
         [Theory(DisplayName = "AddLink (pass)")]
@@ -111,12 +124,12 @@ namespace MeyerCorp.HateoasBuilder.Test
         [InlineData("http://foo.bar/value1", "base", "value1")]
         public void LinkBuilder5Test(string result, string relLabel, string rawRelativeUrl)
         {
-            var test = new LinkBuilder("http://foo.bar");
+            var test = "http://foo.bar".AddLink("self", "baseUrl");
 
             var links = test.AddLink(relLabel, rawRelativeUrl).Build();
 
-            Assert.Equal(relLabel, links.First().Rel);
-            Assert.Equal(result, links.First().Href);
+            Assert.Equal(relLabel, links.Last().Rel);
+            Assert.Equal(result, links.Last().Href);
         }
     }
 }


### PR DESCRIPTION
`LinkInformation` class has been created to make managing adding query parameters via `AddParameters` to a link that was created previously with an `AddLink`, `AddRouteLink`, or even `AddQueryLink` as well as ignoring adding parameters when an `AddXXLink` was ignored by parametric condition.

Overall it makes things better and final URL generation is now almost completely in one place.